### PR TITLE
Limit Entries Not Requiring Paid Form

### DIFF
--- a/css/btx-form-builder.css
+++ b/css/btx-form-builder.css
@@ -25,7 +25,9 @@
 .form_builder_object.form_builder_full .form_builder_text { width: 610px !important; }
 .form_builder_object.form_builder_last { margin-right: 0; }
 
-.form_builder_triplets { float: left; width: 33%; }
+.form_builder_triplets { float: left; width: 15%; }
+
+#form_builder_max_entries { margin-top: 15px; }
 
 /* Icons */
 .form_builder_element .icon { background: url(../images/icons.svg) no-repeat; float: right; height: 16px; width: 16px; }

--- a/js/btx-form-builder.js
+++ b/js/btx-form-builder.js
@@ -65,7 +65,6 @@ var BTXFormBuilder = (function() {
 		$("#form_builder_is_paid").click(function() {
 			$("#form_builder_base_price").toggle();
 			$("#form_builder_early_bird").toggle();
-			$("#form_builder_limit_checkbox").toggle();
 			$("#form_builder_paid_extras").toggle();
 		});
 		$("#form_builder_early_bird input").click(function() {

--- a/modules/btx-form-builder/_form.php
+++ b/modules/btx-form-builder/_form.php
@@ -22,15 +22,21 @@
 		<label>Form Title</label>
 		<input type="text" name="title" placeholder="Please enter a title to describe your form." value="<?=$form["title"]?>" />
 	</fieldset>
+	<fieldset>
+		<div id="form_builder_limit_checkbox">
+			<input type="checkbox" name="limit_entries" id="form_builder_limit_entries"<? if ($form["limit_entries"]) { ?> checked="checked"<? } ?> />
+			<label class="for_checkbox">Limit Number of Entries</label>
+		</div>
+		<div id="form_builder_max_entries" style="display: none;">
+			<label>Maximum Number of Entries</label>
+			<input type="text" name="max_entries" value="<?=$form["max_entries"]?>" />
+		</div>
+	</fieldset>
 	<? if (!empty($settings["accept_payments"])) { ?>
 	<fieldset>
 		<div class="form_builder_triplets">
 			<input type="checkbox" name="paid" id="form_builder_is_paid"<? if ($form["paid"]) { ?> checked="checked"<? } ?> />
 			<label class="for_checkbox">Paid Form</label>	
-		</div>
-		<div id="form_builder_limit_checkbox" class="form_builder_triplets"<? if (!$form["paid"]) { ?> style="display: none;"<? } ?>>
-			<input type="checkbox" name="limit_entries" id="form_builder_limit_entries"<? if ($form["limit_entries"]) { ?> checked="checked"<? } ?> />
-			<label class="for_checkbox">Limit Number of Entries</label>
 		</div>
 		<div id="form_builder_early_bird" class="form_builder_triplets"<? if (!$form["paid"]) { ?> style="display: none;"<? } ?>>
 			<input type="checkbox" name="early_bird" <? if ($form["early_bird_date"]) { ?> checked="checked"<? } ?> />
@@ -50,11 +56,7 @@
 				<input type="text" name="early_bird_base_price" value="$<?=number_format($form["early_bird_base_price"],2)?>" placeholder="Enter a numeric value." />
 			</fieldset>
 		</div>
-		<div class="left" id="form_builder_max_entries"<? if (!$form["limit_entries"]) { ?> style="display: none;"<? } ?>>
-			<label>Maximum Number of Entries</label>
-			<input type="text" name="max_entries" value="<?=$form["max_entries"]?>" />
-		</div>
-		<div class="right" id="form_builder_early_bird_date"<? if (!$form["early_bird_date"]) { ?> style="display: none;"<? } ?>>
+		<div class="left" id="form_builder_early_bird_date"<? if (!$form["early_bird_date"]) { ?> style="display: none;"<? } ?>>
 			<label>Early Bird Cut-off Date <small>(i.e. February 22, 2011 @ 5:30pm)</small></label>
 			<input type="text" name="early_bird_date" value="<? if ($form["early_bird_date"]) { echo date("F j, Y @ g:ia",strtotime($form["early_bird_date"])); } ?>" />
 		</div>


### PR DESCRIPTION
Suggested Enhancement:
A user may want to limit the number of entries on a form even if it is
not paid. This separates the two functionalities so they can operate
independently.
