### PR TITLE
Fix missing directory for file uploads

### DIFF
--- a/templates/routed/btx-form-builder/field-types/process/upload.php
+++ b/templates/routed/btx-form-builder/field-types/process/upload.php
@@ -8,6 +8,9 @@
 		} else {
 			$directory = "files/form-builder/";
 		}
+		if(BigTree::directoryContents($directory) === false){
+			BigTree::makeDirectory($directory);
+		}
 		$value = $storage->store($_FILES[$field_name]["tmp_name"],$_FILES[$field_name]["name"],$directory);
 		$email .= $cms->replaceRelativeRoots($value);
 	} else {


### PR DESCRIPTION
If a user enters a custom directory that does not exist, it needs to be created before the uploaded file is processed. Otherwise it will fail and the file will be lost.
