### PR TITLE
Prevent invalid dates

### DIFF
--- a/templates/routed/btx-form-builder/field-types/process/date.php
+++ b/templates/routed/btx-form-builder/field-types/process/date.php
@@ -3,11 +3,14 @@
 		$d["label"] = "Date";
 	}
 	
-	$value = $_POST[$field_name]["year"]."-".$_POST[$field_name]["month"]."-".$_POST[$field_name]["day"];
-	
 	$email .= $d["label"]."\n";
+	
+	if(checkdate($_POST[$field_name]["month"], $_POST[$field_name]["day"], $_POST[$field_name]["year"])){
+		$value = $_POST[$field_name]["year"]."-".$_POST[$field_name]["month"]."-".$_POST[$field_name]["day"];
+		$email .= date("F j, Y",strtotime($value));	
+	}
+	
 	$email .= str_repeat("-",strlen($d["label"]))."\n";
-	$email .= date("F j, Y",strtotime($value));
 	$email .= "\n\n";
 		
 	if ($d["required"] && (!$_POST[$field_name]["year"] || !$_POST[$field_name]["month"] || !$_POST[$field_name]["day"])) {


### PR DESCRIPTION
If a user did not enter a value in one of the three boxes or entered an invalid value, the date function would return December 31, 1969. POST values need to be checked to confirm they are valid before they are formatted and inserted into the email. If the value as a whole is invalid, proceed as if they entered nothing.
