### PR TITLE
Update FormBuilder To Work With Multi-Site Setup

### DIFF
--- a/templates/routed/btx-form-builder/_header.php
+++ b/templates/routed/btx-form-builder/_header.php
@@ -74,7 +74,7 @@
 			)
 		));
 		
-		$page_link = str_replace("http://", "https://", WWW_ROOT).$bigtree["page"]["path"]."/";
+		$page_link = str_replace("http://", "https://", $cms->getLink($bigtree["page"]["id"]));
 	} else {
-		$page_link = WWW_ROOT.$bigtree["page"]["path"]."/";
+        $page_link = $cms->getLink($bigtree["page"]["id"]);
 	}


### PR DESCRIPTION
Just figured I'd bring this to your attention.
This fix appears to be working well for me, but I'm admittedly not 100% familiar with the internals of FormBuilder.


> This will allow FormBuilder to work with Multi-Site configurations.
> 
> The [page][path] variable contains the route for the sub-site, so that would inadvertently end up in your final URL.